### PR TITLE
Fix invalid LinkedIn URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Created by **Greg Madison**
 Interaction Designer & XR/AI Explorer  
 
 - 🌐 [Portfolio / Website](https://www.spatialcomputing.design)  
-- 💼 [LinkedIn](https://https://www.linkedin.com/in/gregmadison/)  
+- 💼 [LinkedIn](https://www.linkedin.com/in/gregmadison/)  
 - 🐦 [Twitter / X](https://x.com/GregMadison)  
 - 🎥 [YouTube](https://www.youtube.com/@GregMadison)
 


### PR DESCRIPTION
## Summary
- remove duplicated protocol from LinkedIn link in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0bd41c1ac8328a30d1f802874c00e